### PR TITLE
feat: enhance segment picker

### DIFF
--- a/demo/segment-picker-demo.html
+++ b/demo/segment-picker-demo.html
@@ -107,7 +107,7 @@
                 main.appendChild(exportFmtLabel);
                 const formatSel = dce("select");
                 formatSel.id = "format";
-                ["wav", "ogg"].forEach(f => {
+                ["wav", "ogg", "mp3", "aac", "flac"].forEach(f => {
                     const opt = dce("option");
                     opt.value = f;
                     opt.innerHTML = f;
@@ -148,7 +148,15 @@
                 }
                 redraw();
 
-                function addCut(t) {
+                function toggleCut(t) {
+                    const thresh = 5 / canvas.width * buffer.duration;
+                    for (let i = 0; i < cuts.length; i++) {
+                        if (Math.abs(cuts[i] - t) < thresh) {
+                            cuts.splice(i, 1);
+                            redraw();
+                            return;
+                        }
+                    }
                     cuts.push(t);
                     cuts.sort((a, b) => a - b);
                     redraw();
@@ -158,10 +166,10 @@
                     const rect = canvas.getBoundingClientRect();
                     const x = ev.clientX - rect.left;
                     const t = x / canvas.width * buffer.duration;
-                    addCut(t);
+                    toggleCut(t);
                 };
 
-                markBtn.onclick = () => addCut(audio.currentTime);
+                markBtn.onclick = () => toggleCut(audio.currentTime);
 
                 exportBtn.onclick = async () => {
                     if (cuts.length % 2 === 1) {
@@ -192,18 +200,20 @@
                     drawWaveform(outCanvas, outBuf);
 
                     // Encode
-                    let blob;
+                    let blob, ext = formatSel.value;
                     if (formatSel.value === "wav") {
                         blob = new Blob([encodeWAV(outBuf)], {type: "audio/wav"});
                     } else {
-                        const data = await encodeOpusOgg(libav, outBuf);
-                        blob = new Blob([data.buffer], {type: "audio/ogg"});
+                        const fmt = formatMap[formatSel.value];
+                        const data = await encodeWithLibAV(libav, outBuf, fmt);
+                        blob = new Blob([data.buffer], {type: fmt.mime});
+                        ext = fmt.ext;
                     }
                     outAudio.src = URL.createObjectURL(blob);
 
                     const link = dce("a");
                     link.href = outAudio.src;
-                    link.download = `output.${formatSel.value}`;
+                    link.download = `output.${ext}`;
                     link.innerHTML = "Download";
                     main.appendChild(link);
                 };
@@ -262,12 +272,19 @@
                     return out.buffer;
                 }
 
-                async function encodeOpusOgg(libav, buf) {
+                const formatMap = {
+                    ogg: {codec: "libopus", ext: "ogg", mime: "audio/ogg"},
+                    mp3: {codec: "libmp3lame", ext: "mp3", mime: "audio/mpeg"},
+                    aac: {codec: "aac", ext: "aac", mime: "audio/aac"},
+                    flac: {codec: "flac", ext: "flac", mime: "audio/flac"}
+                };
+
+                async function encodeWithLibAV(libav, buf, fmt) {
                     const sr = buf.sampleRate;
                     const chs = buf.numberOfChannels;
                     const channel_layout = chs === 1 ? 4 : 3;
                     const [codec, c, frame, pkt, frame_size] =
-                        await libav.ff_init_encoder("libopus", {
+                        await libav.ff_init_encoder(fmt.codec, {
                             ctx: {
                                 bit_rate: 128000,
                                 sample_fmt: libav.AV_SAMPLE_FMT_FLT,
@@ -278,7 +295,7 @@
                             time_base: [1, sr]
                         });
                     const [oc, , pb] = await libav.ff_init_muxer(
-                        {filename: "out.ogg", open: true}, [[c, 1, sr]]);
+                        {filename: `out.${fmt.ext}`, open: true}, [[c, 1, sr]]);
                     await libav.avformat_write_header(oc, 0);
                     const inter = new Float32Array(buf.length * chs);
                     for (let ch = 0; ch < chs; ch++) {
@@ -302,8 +319,8 @@
                     const packets = await libav.ff_encode_multi(c, frame, pkt, frames, true);
                     await libav.ff_write_multi(oc, pkt, packets);
                     await libav.av_write_trailer(oc);
-                    const data = await libav.readFile("out.ogg");
-                    await libav.unlink("out.ogg");
+                    const data = await libav.readFile(`out.${fmt.ext}`);
+                    await libav.unlink(`out.${fmt.ext}`);
                     await libav.ff_free_muxer(oc, pb);
                     await libav.ff_free_encoder(c, frame, pkt);
                     return data;


### PR DESCRIPTION
## Summary
- allow removing a mark by clicking near an existing cut
- export selections to additional audio formats like mp3, aac, and flac

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68a56690b95483308908ba458bef4b4c