### PR TITLE
Handle supported codecs in segment picker demo

### DIFF
--- a/demo/segment-picker-demo.html
+++ b/demo/segment-picker-demo.html
@@ -66,10 +66,15 @@
                 const libav = await LibAV.LibAV();
 
                 const formatMap = {};
-                if (await libav.avcodec_find_encoder_by_name("libopus"))
-                    formatMap.ogg = {codec: "libopus", ext: "ogg", mime: "audio/ogg", sample_fmt: libav.AV_SAMPLE_FMT_FLT};
-                if (await libav.avcodec_find_encoder_by_name("flac"))
-                    formatMap.flac = {codec: "flac", ext: "flac", mime: "audio/flac", sample_fmt: libav.AV_SAMPLE_FMT_S16};
+                async function addFormat(name, codec, ext, mime, sample_fmt) {
+                    if (await libav.avcodec_find_encoder_by_name(codec))
+                        formatMap[name] = {codec, ext, mime, sample_fmt};
+                }
+                await addFormat("ogg", "libopus", "ogg", "audio/ogg", libav.AV_SAMPLE_FMT_FLT);
+                await addFormat("flac", "flac", "flac", "audio/flac", libav.AV_SAMPLE_FMT_S16);
+                await addFormat("mp3", "libmp3lame", "mp3", "audio/mpeg", libav.AV_SAMPLE_FMT_FLTP);
+                await addFormat("aac", "aac", "m4a", "audio/mp4", libav.AV_SAMPLE_FMT_FLTP);
+                await addFormat("vorbis", "libvorbis", "ogg", "audio/ogg", libav.AV_SAMPLE_FMT_FLTP);
 
                 // Load the audio file
                 const file = await new Promise(res => {
@@ -305,34 +310,58 @@
                     const [oc, , pb] = await libav.ff_init_muxer(
                         {filename: `out.${fmt.ext}`, open: true}, [[c, 1, sr]]);
                     await libav.avformat_write_header(oc, 0);
-                    let inter;
-                    if (fmt.sample_fmt === libav.AV_SAMPLE_FMT_S16) {
-                        inter = new Int16Array(buf.length * chs);
-                        for (let ch = 0; ch < chs; ch++) {
-                            const data = buf.getChannelData(ch);
-                            for (let i = 0; i < buf.length; i++)
-                                inter[i*chs + ch] = Math.max(-1, Math.min(1, data[i])) * 0x7fff;
-                        }
-                    } else {
-                        inter = new Float32Array(buf.length * chs);
-                        for (let ch = 0; ch < chs; ch++) {
-                            const data = buf.getChannelData(ch);
-                            for (let i = 0; i < buf.length; i++)
-                                inter[i*chs + ch] = data[i];
-                        }
-                    }
                     const frames = [];
                     let pts = 0;
-                    for (let i = 0; i < buf.length; i += frame_size) {
-                        const end = Math.min(i + frame_size, buf.length);
-                        frames.push({
-                            data: inter.subarray(i*chs, end*chs),
-                            channel_layout,
-                            format: fmt.sample_fmt,
-                            pts,
-                            sample_rate: sr
-                        });
-                        pts += end - i;
+                    if (fmt.sample_fmt === libav.AV_SAMPLE_FMT_S16 ||
+                        fmt.sample_fmt === libav.AV_SAMPLE_FMT_FLT) {
+                        const inter = fmt.sample_fmt === libav.AV_SAMPLE_FMT_S16
+                            ? new Int16Array(buf.length * chs)
+                            : new Float32Array(buf.length * chs);
+                        for (let ch = 0; ch < chs; ch++) {
+                            const data = buf.getChannelData(ch);
+                            for (let i = 0; i < buf.length; i++) {
+                                const v = fmt.sample_fmt === libav.AV_SAMPLE_FMT_S16
+                                    ? Math.max(-1, Math.min(1, data[i])) * 0x7fff
+                                    : data[i];
+                                inter[i*chs + ch] = v;
+                            }
+                        }
+                        for (let i = 0; i < buf.length; i += frame_size) {
+                            const end = Math.min(i + frame_size, buf.length);
+                            frames.push({
+                                data: inter.subarray(i*chs, end*chs),
+                                channel_layout,
+                                format: fmt.sample_fmt,
+                                pts,
+                                sample_rate: sr
+                            });
+                            pts += end - i;
+                        }
+                    } else {
+                        const planes = [];
+                        const makePlane = fmt.sample_fmt === libav.AV_SAMPLE_FMT_S16P
+                            ? () => new Int16Array(buf.length)
+                            : () => new Float32Array(buf.length);
+                        for (let ch = 0; ch < chs; ch++) {
+                            const data = buf.getChannelData(ch);
+                            const plane = makePlane();
+                            for (let i = 0; i < buf.length; i++)
+                                plane[i] = fmt.sample_fmt === libav.AV_SAMPLE_FMT_S16P
+                                    ? Math.max(-1, Math.min(1, data[i])) * 0x7fff
+                                    : data[i];
+                            planes.push(plane);
+                        }
+                        for (let i = 0; i < buf.length; i += frame_size) {
+                            const end = Math.min(i + frame_size, buf.length);
+                            frames.push({
+                                data: planes.map(p => p.subarray(i, end)),
+                                channel_layout,
+                                format: fmt.sample_fmt,
+                                pts,
+                                sample_rate: sr
+                            });
+                            pts += end - i;
+                        }
                     }
                     const packets = await libav.ff_encode_multi(c, frame, pkt, frames, true);
                     await libav.ff_write_multi(oc, pkt, packets);

--- a/demo/segment-picker-demo.html
+++ b/demo/segment-picker-demo.html
@@ -65,6 +65,12 @@
                 });
                 const libav = await LibAV.LibAV();
 
+                const formatMap = {};
+                if (await libav.avcodec_find_encoder_by_name("libopus"))
+                    formatMap.ogg = {codec: "libopus", ext: "ogg", mime: "audio/ogg", sample_fmt: libav.AV_SAMPLE_FMT_FLT};
+                if (await libav.avcodec_find_encoder_by_name("flac"))
+                    formatMap.flac = {codec: "flac", ext: "flac", mime: "audio/flac", sample_fmt: libav.AV_SAMPLE_FMT_S16};
+
                 // Load the audio file
                 const file = await new Promise(res => {
                     main.innerHTML = "";
@@ -107,7 +113,7 @@
                 main.appendChild(exportFmtLabel);
                 const formatSel = dce("select");
                 formatSel.id = "format";
-                ["wav", "ogg", "mp3", "aac", "flac"].forEach(f => {
+                ["wav", ...Object.keys(formatMap)].forEach(f => {
                     const opt = dce("option");
                     opt.value = f;
                     opt.innerHTML = f;
@@ -281,13 +287,6 @@
                     return out.buffer;
                 }
 
-                const formatMap = {
-                    ogg: {codec: "libopus", ext: "ogg", mime: "audio/ogg"},
-                    mp3: {codec: "libmp3lame", ext: "mp3", mime: "audio/mpeg"},
-                    aac: {codec: "aac", ext: "aac", mime: "audio/aac"},
-                    flac: {codec: "flac", ext: "flac", mime: "audio/flac"}
-                };
-
                 async function encodeWithLibAV(libav, buf, fmt) {
                     const sr = buf.sampleRate;
                     const chs = buf.numberOfChannels;
@@ -296,7 +295,7 @@
                         await libav.ff_init_encoder(fmt.codec, {
                             ctx: {
                                 bit_rate: 128000,
-                                sample_fmt: libav.AV_SAMPLE_FMT_FLT,
+                                sample_fmt: fmt.sample_fmt,
                                 sample_rate: sr,
                                 channel_layout,
                                 channels: chs
@@ -306,11 +305,21 @@
                     const [oc, , pb] = await libav.ff_init_muxer(
                         {filename: `out.${fmt.ext}`, open: true}, [[c, 1, sr]]);
                     await libav.avformat_write_header(oc, 0);
-                    const inter = new Float32Array(buf.length * chs);
-                    for (let ch = 0; ch < chs; ch++) {
-                        const data = buf.getChannelData(ch);
-                        for (let i = 0; i < buf.length; i++)
-                            inter[i*chs + ch] = data[i];
+                    let inter;
+                    if (fmt.sample_fmt === libav.AV_SAMPLE_FMT_S16) {
+                        inter = new Int16Array(buf.length * chs);
+                        for (let ch = 0; ch < chs; ch++) {
+                            const data = buf.getChannelData(ch);
+                            for (let i = 0; i < buf.length; i++)
+                                inter[i*chs + ch] = Math.max(-1, Math.min(1, data[i])) * 0x7fff;
+                        }
+                    } else {
+                        inter = new Float32Array(buf.length * chs);
+                        for (let ch = 0; ch < chs; ch++) {
+                            const data = buf.getChannelData(ch);
+                            for (let i = 0; i < buf.length; i++)
+                                inter[i*chs + ch] = data[i];
+                        }
                     }
                     const frames = [];
                     let pts = 0;
@@ -319,7 +328,7 @@
                         frames.push({
                             data: inter.subarray(i*chs, end*chs),
                             channel_layout,
-                            format: libav.AV_SAMPLE_FMT_FLT,
+                            format: fmt.sample_fmt,
                             pts,
                             sample_rate: sr
                         });

--- a/demo/segment-picker-demo.html
+++ b/demo/segment-picker-demo.html
@@ -28,33 +28,42 @@
                 const main = dce("div");
                 document.body.appendChild(main);
 
-                const version = "6.7.7.1.1";
-                const variant = "obsolete";
+                const variant = await new Promise(res => {
+                    const label = dce("label");
+                    label.innerHTML = "Variant:&nbsp;";
+                    label.htmlFor = "variant";
+                    main.appendChild(label);
+                    const vbox = dce("input");
+                    vbox.type = "text";
+                    vbox.id = "variant";
+                    vbox.value = "obsolete";
+                    main.appendChild(vbox);
+                    const ok = dce("button");
+                    ok.innerHTML = "Load";
+                    main.appendChild(ok);
+
+                    vbox.focus();
+                    vbox.select();
+
+                    vbox.onkeypress = ev => {
+                        if (ev.key === "Enter")
+                            res(vbox.value);
+                    };
+                    ok.onclick = () => res(vbox.value);
+                });
                 main.innerHTML = "Loading...";
 
-                const base = `../libav.js-${version}/dist`;
+                const base = "../libav.js-6.7.7.1.1/dist";
                 LibAV = {base};
+                const version = "6.7.7.1.1";
                 await new Promise(res => {
                     const scr = dce("script");
-                    scr.src = `${base}/libav-${version}-${variant}.js?${Math.random()}`;
+                    scr.src = `${base}/libav-${version}-${variant}.js`;
                     scr.onload = res;
                     scr.onerror = () => alert("Failed to load variant!");
                     document.body.appendChild(scr);
                 });
                 const libav = await LibAV.LibAV();
-
-                const formatMap = {};
-                async function addFormat(name, codec, ext, mime, sample_fmt) {
-                    const enc = await libav.avcodec_find_encoder_by_name(codec);
-                    console.log(`encoder ${codec}: ${enc ? "found" : "missing"}`);
-                    if (enc)
-                        formatMap[name] = {codec, ext, mime, sample_fmt};
-                }
-                await addFormat("ogg", "libopus", "ogg", "audio/ogg", libav.AV_SAMPLE_FMT_FLT);
-                await addFormat("flac", "flac", "flac", "audio/flac", libav.AV_SAMPLE_FMT_S16);
-                await addFormat("mp3", "libmp3lame", "mp3", "audio/mpeg", libav.AV_SAMPLE_FMT_FLTP);
-                await addFormat("vorbis", "libvorbis", "ogg", "audio/ogg", libav.AV_SAMPLE_FMT_FLTP);
-                console.log("formats:", Object.keys(formatMap));
 
                 // Load the audio file
                 const file = await new Promise(res => {
@@ -98,7 +107,7 @@
                 main.appendChild(exportFmtLabel);
                 const formatSel = dce("select");
                 formatSel.id = "format";
-                ["wav", ...Object.keys(formatMap)].forEach(f => {
+                ["wav", "ogg", "mp3", "aac", "flac"].forEach(f => {
                     const opt = dce("option");
                     opt.value = f;
                     opt.innerHTML = f;
@@ -272,6 +281,13 @@
                     return out.buffer;
                 }
 
+                const formatMap = {
+                    ogg: {codec: "libopus", ext: "ogg", mime: "audio/ogg"},
+                    mp3: {codec: "libmp3lame", ext: "mp3", mime: "audio/mpeg"},
+                    aac: {codec: "aac", ext: "aac", mime: "audio/aac"},
+                    flac: {codec: "flac", ext: "flac", mime: "audio/flac"}
+                };
+
                 async function encodeWithLibAV(libav, buf, fmt) {
                     const sr = buf.sampleRate;
                     const chs = buf.numberOfChannels;
@@ -280,7 +296,7 @@
                         await libav.ff_init_encoder(fmt.codec, {
                             ctx: {
                                 bit_rate: 128000,
-                                sample_fmt: fmt.sample_fmt,
+                                sample_fmt: libav.AV_SAMPLE_FMT_FLT,
                                 sample_rate: sr,
                                 channel_layout,
                                 channels: chs
@@ -290,58 +306,24 @@
                     const [oc, , pb] = await libav.ff_init_muxer(
                         {filename: `out.${fmt.ext}`, open: true}, [[c, 1, sr]]);
                     await libav.avformat_write_header(oc, 0);
+                    const inter = new Float32Array(buf.length * chs);
+                    for (let ch = 0; ch < chs; ch++) {
+                        const data = buf.getChannelData(ch);
+                        for (let i = 0; i < buf.length; i++)
+                            inter[i*chs + ch] = data[i];
+                    }
                     const frames = [];
                     let pts = 0;
-                    if (fmt.sample_fmt === libav.AV_SAMPLE_FMT_S16 ||
-                        fmt.sample_fmt === libav.AV_SAMPLE_FMT_FLT) {
-                        const inter = fmt.sample_fmt === libav.AV_SAMPLE_FMT_S16
-                            ? new Int16Array(buf.length * chs)
-                            : new Float32Array(buf.length * chs);
-                        for (let ch = 0; ch < chs; ch++) {
-                            const data = buf.getChannelData(ch);
-                            for (let i = 0; i < buf.length; i++) {
-                                const v = fmt.sample_fmt === libav.AV_SAMPLE_FMT_S16
-                                    ? Math.max(-1, Math.min(1, data[i])) * 0x7fff
-                                    : data[i];
-                                inter[i*chs + ch] = v;
-                            }
-                        }
-                        for (let i = 0; i < buf.length; i += frame_size) {
-                            const end = Math.min(i + frame_size, buf.length);
-                            frames.push({
-                                data: inter.subarray(i*chs, end*chs),
-                                channel_layout,
-                                format: fmt.sample_fmt,
-                                pts,
-                                sample_rate: sr
-                            });
-                            pts += end - i;
-                        }
-                    } else {
-                        const planes = [];
-                        const makePlane = fmt.sample_fmt === libav.AV_SAMPLE_FMT_S16P
-                            ? () => new Int16Array(buf.length)
-                            : () => new Float32Array(buf.length);
-                        for (let ch = 0; ch < chs; ch++) {
-                            const data = buf.getChannelData(ch);
-                            const plane = makePlane();
-                            for (let i = 0; i < buf.length; i++)
-                                plane[i] = fmt.sample_fmt === libav.AV_SAMPLE_FMT_S16P
-                                    ? Math.max(-1, Math.min(1, data[i])) * 0x7fff
-                                    : data[i];
-                            planes.push(plane);
-                        }
-                        for (let i = 0; i < buf.length; i += frame_size) {
-                            const end = Math.min(i + frame_size, buf.length);
-                            frames.push({
-                                data: planes.map(p => p.subarray(i, end)),
-                                channel_layout,
-                                format: fmt.sample_fmt,
-                                pts,
-                                sample_rate: sr
-                            });
-                            pts += end - i;
-                        }
+                    for (let i = 0; i < buf.length; i += frame_size) {
+                        const end = Math.min(i + frame_size, buf.length);
+                        frames.push({
+                            data: inter.subarray(i*chs, end*chs),
+                            channel_layout,
+                            format: libav.AV_SAMPLE_FMT_FLT,
+                            pts,
+                            sample_rate: sr
+                        });
+                        pts += end - i;
                     }
                     const packets = await libav.ff_encode_multi(c, frame, pkt, frames, true);
                     await libav.ff_write_multi(oc, pkt, packets);

--- a/demo/segment-picker-demo.html
+++ b/demo/segment-picker-demo.html
@@ -53,12 +53,11 @@
                 });
                 main.innerHTML = "Loading...";
 
-                const base = "../libav.js-6.7.7.1.1/dist";
+                const base = "../dist";
                 LibAV = {base};
-                const version = "6.7.7.1.1";
                 await new Promise(res => {
                     const scr = dce("script");
-                    scr.src = `${base}/libav-${version}-${variant}.js`;
+                    scr.src = `${base}/libav-${variant}.js?${Math.random()}`;
                     scr.onload = res;
                     scr.onerror = () => alert("Failed to load variant!");
                     document.body.appendChild(scr);

--- a/demo/segment-picker-demo.html
+++ b/demo/segment-picker-demo.html
@@ -28,6 +28,7 @@
                 const main = dce("div");
                 document.body.appendChild(main);
 
+                const version = "6.7.7.1.1";
                 const variant = await new Promise(res => {
                     const label = dce("label");
                     label.innerHTML = "Variant:&nbsp;";
@@ -36,7 +37,7 @@
                     const vbox = dce("input");
                     vbox.type = "text";
                     vbox.id = "variant";
-                    vbox.value = "all";
+                    vbox.value = "default";
                     main.appendChild(vbox);
                     const ok = dce("button");
                     ok.innerHTML = "Load";
@@ -57,7 +58,7 @@
                 LibAV = {base};
                 await new Promise(res => {
                     const scr = dce("script");
-                    scr.src = `${base}/libav-${variant}.js?${Math.random()}`;
+                    scr.src = `${base}/libav-${version}-${variant}.js?${Math.random()}`;
                     scr.onload = res;
                     scr.onerror = () => alert("Failed to load variant!");
                     document.body.appendChild(scr);

--- a/demo/segment-picker-demo.html
+++ b/demo/segment-picker-demo.html
@@ -54,7 +54,7 @@
                 });
                 main.innerHTML = "Loading...";
 
-                const base = "../dist";
+                const base = `../libav.js-${version}/dist`;
                 LibAV = {base};
                 await new Promise(res => {
                     const scr = dce("script");

--- a/demo/segment-picker-demo.html
+++ b/demo/segment-picker-demo.html
@@ -36,7 +36,7 @@
                     const vbox = dce("input");
                     vbox.type = "text";
                     vbox.id = "variant";
-                    vbox.value = "default";
+                    vbox.value = "all";
                     main.appendChild(vbox);
                     const ok = dce("button");
                     ok.innerHTML = "Load";
@@ -67,7 +67,9 @@
 
                 const formatMap = {};
                 async function addFormat(name, codec, ext, mime, sample_fmt) {
-                    if (await libav.avcodec_find_encoder_by_name(codec))
+                    const enc = await libav.avcodec_find_encoder_by_name(codec);
+                    console.log(`encoder ${codec}: ${enc ? "found" : "missing"}`);
+                    if (enc)
                         formatMap[name] = {codec, ext, mime, sample_fmt};
                 }
                 await addFormat("ogg", "libopus", "ogg", "audio/ogg", libav.AV_SAMPLE_FMT_FLT);
@@ -75,6 +77,7 @@
                 await addFormat("mp3", "libmp3lame", "mp3", "audio/mpeg", libav.AV_SAMPLE_FMT_FLTP);
                 await addFormat("aac", "aac", "m4a", "audio/mp4", libav.AV_SAMPLE_FMT_FLTP);
                 await addFormat("vorbis", "libvorbis", "ogg", "audio/ogg", libav.AV_SAMPLE_FMT_FLTP);
+                console.log("formats:", Object.keys(formatMap));
 
                 // Load the audio file
                 const file = await new Promise(res => {

--- a/demo/segment-picker-demo.html
+++ b/demo/segment-picker-demo.html
@@ -29,29 +29,7 @@
                 document.body.appendChild(main);
 
                 const version = "6.7.7.1.1";
-                const variant = await new Promise(res => {
-                    const label = dce("label");
-                    label.innerHTML = "Variant:&nbsp;";
-                    label.htmlFor = "variant";
-                    main.appendChild(label);
-                    const vbox = dce("input");
-                    vbox.type = "text";
-                    vbox.id = "variant";
-                    vbox.value = "default";
-                    main.appendChild(vbox);
-                    const ok = dce("button");
-                    ok.innerHTML = "Load";
-                    main.appendChild(ok);
-
-                    vbox.focus();
-                    vbox.select();
-
-                    vbox.onkeypress = ev => {
-                        if (ev.key === "Enter")
-                            res(vbox.value);
-                    };
-                    ok.onclick = () => res(vbox.value);
-                });
+                const variant = "obsolete";
                 main.innerHTML = "Loading...";
 
                 const base = `../libav.js-${version}/dist`;
@@ -75,7 +53,6 @@
                 await addFormat("ogg", "libopus", "ogg", "audio/ogg", libav.AV_SAMPLE_FMT_FLT);
                 await addFormat("flac", "flac", "flac", "audio/flac", libav.AV_SAMPLE_FMT_S16);
                 await addFormat("mp3", "libmp3lame", "mp3", "audio/mpeg", libav.AV_SAMPLE_FMT_FLTP);
-                await addFormat("aac", "aac", "m4a", "audio/mp4", libav.AV_SAMPLE_FMT_FLTP);
                 await addFormat("vorbis", "libvorbis", "ogg", "audio/ogg", libav.AV_SAMPLE_FMT_FLTP);
                 console.log("formats:", Object.keys(formatMap));
 


### PR DESCRIPTION
## Summary
- Detect available encoders and limit export formats accordingly
- Use correct audio sample format when encoding with libav.js

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68a67df4e4fc8330b498af47ec1a9f24