### PR TITLE
feat: log supported file formats

### DIFF
--- a/funcs.json
+++ b/funcs.json
@@ -260,7 +260,9 @@
             ["av_read_frame", "number", ["number", "number"], {"async": true, "returnsErrno": true}],
             ["av_seek_frame", "number", ["number", "number", "number", "number"], {"async": true, "returnsErrno": true, "notypes": true}],
             ["av_write_frame", "number", ["number", "number"]],
-            ["av_write_trailer", "number", ["number"]]
+            ["av_write_trailer", "number", ["number"]],
+            ["av_demuxer_iterate_js", "number", ["number"]],
+            ["av_muxer_iterate_js", "number", ["number"]]
         ],
 
         "fs": [
@@ -313,6 +315,14 @@
                 "duration",
                 "durationhi",
                 {"name": "time_base", "rational": true}
+            ]],
+            ["AVInputFormat", [
+                {"name": "name", "string": true},
+                {"name": "extensions", "string": true}
+            ]],
+            ["AVOutputFormat", [
+                {"name": "name", "string": true},
+                {"name": "extensions", "string": true}
             ]]
         ],
 

--- a/src/b-avformat.c
+++ b/src/b-avformat.c
@@ -37,6 +37,18 @@ BL(int64_t, duration)
 #undef B
 #undef BL
 
+/* AVInputFormat */
+#define B(type, field) A(AVInputFormat, type, field)
+B(const char *, name)
+B(const char *, extensions)
+#undef B
+
+/* AVOutputFormat */
+#define B(type, field) A(AVOutputFormat, type, field)
+B(const char *, name)
+B(const char *, extensions)
+#undef B
+
 RAT(AVStream, time_base)
 
 int avformat_seek_file_min(
@@ -55,6 +67,14 @@ int avformat_seek_file_approx(
     AVFormatContext *s, int stream_index, int64_t ts, int flags
 ) {
     return avformat_seek_file(s, stream_index, INT64_MIN, ts, INT64_MAX, flags);
+}
+
+AVInputFormat *av_demuxer_iterate_js(void **opaque) {
+    return av_demuxer_iterate(opaque);
+}
+
+AVOutputFormat *av_muxer_iterate_js(void **opaque) {
+    return av_muxer_iterate(opaque);
 }
 
 AVFormatContext *avformat_alloc_output_context2_js(AVOutputFormat *oformat,

--- a/src/p-avformat.in.js
+++ b/src/p-avformat.in.js
@@ -1041,3 +1041,30 @@ Module.ff_read_multi = function(fmt_ctx, pkt, devfile, opts) {
     console.log("[libav.js] ff_read_multi is deprecated. Use ff_read_frame_multi.");
     return Module.ff_read_frame_multi(fmt_ctx, pkt, opts);
 };
+
+/**
+ * Debug helper to list supported container formats.
+ * Returns [demuxers, muxers].
+ */
+/// @types ff_detect_formats@sync(): @promsync@[string[], string[]]@
+var ff_detect_formats = Module.ff_detect_formats = function() {
+    var demuxers = [], muxers = [];
+    var opaque = malloc(4);
+    if (!opaque)
+        throw new Error("Failed to malloc");
+    Module.HEAPU32[opaque >> 2] = 0;
+
+    var fmt;
+    while ((fmt = av_demuxer_iterate_js(opaque)))
+        demuxers.push(AVInputFormat_name(fmt));
+
+    Module.HEAPU32[opaque >> 2] = 0;
+    while ((fmt = av_muxer_iterate_js(opaque)))
+        muxers.push(AVOutputFormat_name(fmt));
+
+    free(opaque);
+
+    console.debug("Supported demuxers: " + demuxers.join(", "));
+    console.debug("Supported muxers: " + muxers.join(", "));
+    return [demuxers, muxers];
+};


### PR DESCRIPTION
## Summary
- expose AVInputFormat/AVOutputFormat names and iterate wrappers
- add ff_detect_formats helper that logs supported demuxers and muxers

## Testing
- ⚠️ no tests were run


------
https://chatgpt.com/codex/tasks/task_e_68a6c6448a7c8330a26c159484e62d50