### PR TITLE
Verify codec support in segment picker demo

### DIFF
--- a/demo/segment-picker-demo.html
+++ b/demo/segment-picker-demo.html
@@ -119,6 +119,14 @@
                 const channel_layout = chs === 1 ? 4 : 3;
                 console.log(`Input audio: sampleRate=${sr}, channels=${chs}, layout=${channel_layout}`);
                 const supportedFormats = ["wav"];
+                const commonFmts = [
+                    libav.AV_SAMPLE_FMT_FLT,
+                    libav.AV_SAMPLE_FMT_FLTP,
+                    libav.AV_SAMPLE_FMT_S16,
+                    libav.AV_SAMPLE_FMT_S16P,
+                    libav.AV_SAMPLE_FMT_S32,
+                    libav.AV_SAMPLE_FMT_S32P
+                ];
                 for (const [fmt, info] of Object.entries(formatMap)) {
                     console.log(`Probing encoder ${info.codec} for format ${fmt}`);
                     const codec = await libav.avcodec_find_encoder_by_name(info.codec);
@@ -127,44 +135,50 @@
                         continue;
                     }
 
-                    // Determine a usable sample format for probing
                     let fmts = await libav.AVCodec_sample_fmts(codec);
-                    let sample_fmt = libav.AV_SAMPLE_FMT_FLT;
-                    if (fmts && fmts.length) {
+                    let candidates = [];
+                    if (fmts && fmts.length && fmts[0] !== -1) {
                         const fmtNames = [];
                         for (const f of fmts) {
                             if (f === -1) break;
+                            candidates.push(f);
                             fmtNames.push(await libav.av_get_sample_fmt_name(f));
                         }
                         console.log(`Encoder ${info.codec} supports sample formats: ${fmtNames.join(", ")}`);
-                        if (!fmts.includes(sample_fmt)) sample_fmt = fmts[0];
                     } else {
-                        console.log(`No sample format list for encoder ${info.codec}; using default`);
-                        sample_fmt = undefined;
+                        console.log(`No sample format list for encoder ${info.codec}; trying common formats`);
+                        candidates = commonFmts;
                     }
-                    const sfmtName = sample_fmt === undefined ? "default" : await libav.av_get_sample_fmt_name(sample_fmt);
-                    console.log(`Attempting to initialize ${info.codec} with sample format ${sfmtName}`);
 
-                    let canUse = true;
-                    try {
-                        const encOpts = {
-                            ctx: {
-                                bit_rate: 128000,
-                                sample_rate: sr,
-                                channel_layout,
-                                channels: chs
-                            },
-                            time_base: [1, sr]
-                        };
-                        if (sample_fmt !== undefined)
-                            encOpts.ctx.sample_fmt = sample_fmt;
-                        const [, c, frame, pkt] = await libav.ff_init_encoder(info.codec, encOpts);
-                        await libav.ff_free_encoder(c, frame, pkt);
-                    } catch (err) {
-                        console.log(`Encoder ${info.codec} failed init:`, err);
-                        canUse = false;
+                    let chosenFmt;
+                    for (const f of candidates) {
+                        const sfmtName = await libav.av_get_sample_fmt_name(f);
+                        console.log(`Attempting to initialize ${info.codec} with sample format ${sfmtName}`);
+                        try {
+                            const encOpts = {
+                                ctx: {
+                                    bit_rate: 128000,
+                                    sample_rate: sr,
+                                    channel_layout,
+                                    channels: chs,
+                                    sample_fmt: f
+                                },
+                                time_base: [1, sr]
+                            };
+                            const [, c, frame, pkt] = await libav.ff_init_encoder(info.codec, encOpts);
+                            await libav.ff_free_encoder(c, frame, pkt);
+                            chosenFmt = f;
+                            console.log(`Encoder ${info.codec} initialized with sample format ${sfmtName}`);
+                            break;
+                        } catch (err) {
+                            console.log(`Encoder ${info.codec} failed init with ${sfmtName}:`, err);
+                        }
                     }
-                    if (canUse) supportedFormats.push(fmt);
+
+                    if (chosenFmt !== undefined) {
+                        info.sample_fmt = chosenFmt;
+                        supportedFormats.push(fmt);
+                    }
                 }
                 console.log("Final supported formats:", supportedFormats);
                 supportedFormats.forEach(f => {
@@ -363,46 +377,23 @@
                     const channel_layout = chs === 1 ? 4 : 3;
                     console.log(`Encoding using ${fmt.codec}: sr=${sr}, chs=${chs}, layout=${channel_layout}, samples=${buf.length}`);
 
-                    // Determine a supported sample format and log capabilities
-                    let sample_fmt = libav.AV_SAMPLE_FMT_FLT;
-                    const codec = await libav.avcodec_find_encoder_by_name(fmt.codec);
-                    if (codec) {
-                        const fmts = await libav.AVCodec_sample_fmts(codec);
-                        console.log(`Raw sample_fmts for ${fmt.codec}:`, fmts);
-                        if (fmts && fmts.length) {
-                            const fmtNames = [];
-                            for (const f of fmts) {
-                                if (f === -1) break;
-                                fmtNames.push(await libav.av_get_sample_fmt_name(f));
-                            }
-                            console.log(`Encoder ${fmt.codec} supports sample formats: ${fmtNames.join(", ")}`);
-                            if (!fmts.includes(libav.AV_SAMPLE_FMT_FLT)) {
-                                sample_fmt = fmts[0];
-                                const chosenName = await libav.av_get_sample_fmt_name(sample_fmt);
-                                console.log(`Input format flt unsupported; will encode using ${chosenName}`);
-                            }
-                        } else {
-                            console.log(`No sample format list for encoder ${fmt.codec}; leaving sample_fmt unspecified`);
-                            sample_fmt = undefined;
-                        }
-                    } else {
-                        console.log(`Could not find encoder ${fmt.codec}`);
-                        sample_fmt = undefined;
+                    let sample_fmt = fmt.sample_fmt;
+                    if (sample_fmt === undefined) {
+                        console.log(`No preselected sample_fmt for ${fmt.codec}; defaulting to flt`);
+                        sample_fmt = libav.AV_SAMPLE_FMT_FLT;
                     }
-
-                    const sfmtName = sample_fmt === undefined ? "default" : await libav.av_get_sample_fmt_name(sample_fmt);
+                    const sfmtName = await libav.av_get_sample_fmt_name(sample_fmt);
                     console.log(`Initializing encoder ${fmt.codec} (sr=${sr}, chs=${chs}, layout=${channel_layout}) with sample format ${sfmtName}`);
                     const encOpts = {
                         ctx: {
                             bit_rate: 128000,
                             sample_rate: sr,
                             channel_layout,
-                            channels: chs
+                            channels: chs,
+                            sample_fmt
                         },
                         time_base: [1, sr]
                     };
-                    if (sample_fmt !== undefined)
-                        encOpts.ctx.sample_fmt = sample_fmt;
                     let c, frame, pkt, frame_size;
                     try {
                         [, c, frame, pkt, frame_size] = await libav.ff_init_encoder(fmt.codec, encOpts);

--- a/demo/segment-picker-demo.html
+++ b/demo/segment-picker-demo.html
@@ -235,7 +235,14 @@
                         blob = new Blob([encodeWAV(outBuf)], {type: "audio/wav"});
                     } else {
                         const fmt = formatMap[formatSel.value];
-                        const data = await encodeWithLibAV(libav, outBuf, fmt);
+                        let data;
+                        try {
+                            data = await encodeWithLibAV(libav, outBuf, fmt);
+                        } catch (err) {
+                            console.error("Encoding failed", err);
+                            alert("Encoding failed: " + err);
+                            return;
+                        }
                         blob = new Blob([data.buffer], {type: fmt.mime});
                         ext = fmt.ext;
                     }
@@ -306,17 +313,45 @@
                     const sr = buf.sampleRate;
                     const chs = buf.numberOfChannels;
                     const channel_layout = chs === 1 ? 4 : 3;
-                    const [codec, c, frame, pkt, frame_size] =
+
+                    // Determine a supported sample format and log capabilities
+                    let sample_fmt = libav.AV_SAMPLE_FMT_FLT;
+                    const codec = await libav.avcodec_find_encoder_by_name(fmt.codec);
+                    if (codec) {
+                        const fmts = await libav.AVCodec_sample_fmts(codec);
+                        if (fmts && fmts.length) {
+                            const fmtNames = [];
+                            for (const f of fmts) {
+                                if (f === -1) break;
+                                fmtNames.push(await libav.av_get_sample_fmt_name(f));
+                            }
+                            console.log(`Encoder ${fmt.codec} supports sample formats: ${fmtNames.join(", ")}`);
+                            if (!fmts.includes(libav.AV_SAMPLE_FMT_FLT)) {
+                                sample_fmt = fmts[0];
+                                const chosenName = await libav.av_get_sample_fmt_name(sample_fmt);
+                                console.log(`Input format flt unsupported; will encode using ${chosenName}`);
+                            }
+                        } else {
+                            console.log(`No sample format list for encoder ${fmt.codec}`);
+                        }
+                    } else {
+                        console.log(`Could not find encoder ${fmt.codec}`);
+                    }
+
+                    console.log(`Initializing encoder ${fmt.codec} with sample format ${await libav.av_get_sample_fmt_name(sample_fmt)}`);
+                    const [, c, frame, pkt, frame_size] =
                         await libav.ff_init_encoder(fmt.codec, {
                             ctx: {
                                 bit_rate: 128000,
-                                sample_fmt: libav.AV_SAMPLE_FMT_FLT,
+                                sample_fmt,
                                 sample_rate: sr,
                                 channel_layout,
                                 channels: chs
                             },
                             time_base: [1, sr]
                         });
+                    const ctxFmt = await libav.AVCodecContext_sample_fmt(c);
+                    console.log(`Codec context using sample format ${await libav.av_get_sample_fmt_name(ctxFmt)}`);
                     const [oc, , pb] = await libav.ff_init_muxer(
                         {filename: `out.${fmt.ext}`, open: true}, [[c, 1, sr]]);
                     await libav.avformat_write_header(oc, 0);

--- a/demo/segment-picker-demo.html
+++ b/demo/segment-picker-demo.html
@@ -65,6 +65,13 @@
                 });
                 const libav = await LibAV.LibAV();
 
+                const formatMap = {
+                    ogg: {codec: "libopus", ext: "ogg", mime: "audio/ogg"},
+                    mp3: {codec: "libmp3lame", ext: "mp3", mime: "audio/mpeg"},
+                    aac: {codec: "aac", ext: "aac", mime: "audio/aac"},
+                    flac: {codec: "flac", ext: "flac", mime: "audio/flac"}
+                };
+
                 // Load the audio file
                 const file = await new Promise(res => {
                     main.innerHTML = "";
@@ -107,7 +114,12 @@
                 main.appendChild(exportFmtLabel);
                 const formatSel = dce("select");
                 formatSel.id = "format";
-                ["wav", "ogg", "mp3", "aac", "flac"].forEach(f => {
+                const supportedFormats = ["wav"];
+                for (const [fmt, info] of Object.entries(formatMap)) {
+                    const codec = await libav.avcodec_find_encoder_by_name(info.codec);
+                    if (codec) supportedFormats.push(fmt);
+                }
+                supportedFormats.forEach(f => {
                     const opt = dce("option");
                     opt.value = f;
                     opt.innerHTML = f;
@@ -280,13 +292,6 @@
                             inter[ptr++] = Math.max(-1, Math.min(1, chData[ch][i])) * 0x7fff;
                     return out.buffer;
                 }
-
-                const formatMap = {
-                    ogg: {codec: "libopus", ext: "ogg", mime: "audio/ogg"},
-                    mp3: {codec: "libmp3lame", ext: "mp3", mime: "audio/mpeg"},
-                    aac: {codec: "aac", ext: "aac", mime: "audio/aac"},
-                    flac: {codec: "flac", ext: "flac", mime: "audio/flac"}
-                };
 
                 async function encodeWithLibAV(libav, buf, fmt) {
                     const sr = buf.sampleRate;

--- a/demo/segment-picker-demo.html
+++ b/demo/segment-picker-demo.html
@@ -150,7 +150,7 @@
                         candidates = commonFmts;
                     }
 
-                    let chosenFmt;
+                    let chosenFmt, frameSize;
                     for (const f of candidates) {
                         const sfmtName = await libav.av_get_sample_fmt_name(f);
                         console.log(`Attempting to initialize ${info.codec} with sample format ${sfmtName}`);
@@ -165,9 +165,10 @@
                                 },
                                 time_base: [1, sr]
                             };
-                            const [, c, frame, pkt] = await libav.ff_init_encoder(info.codec, encOpts);
+                            const [, c, frame, pkt, fs] = await libav.ff_init_encoder(info.codec, encOpts);
                             await libav.ff_free_encoder(c, frame, pkt);
                             chosenFmt = f;
+                            frameSize = fs;
                             console.log(`Encoder ${info.codec} initialized with sample format ${sfmtName}`);
                             break;
                         } catch (err) {
@@ -177,7 +178,22 @@
 
                     if (chosenFmt !== undefined) {
                         info.sample_fmt = chosenFmt;
-                        supportedFormats.push(fmt);
+                        info.frame_size = frameSize;
+
+                        // Verify actual encoding works before enabling this format
+                        const testLen = Math.min(buffer.length, (frameSize || sr) * 300);
+                        const testBuf = audioCtx.createBuffer(chs, testLen, sr);
+                        for (let ch = 0; ch < chs; ch++) {
+                            const src = buffer.getChannelData(ch);
+                            testBuf.getChannelData(ch).set(src.subarray(0, testLen));
+                        }
+                        try {
+                            await encodeWithLibAV(libav, testBuf, info);
+                            supportedFormats.push(fmt);
+                            console.log(`Encoder ${info.codec} passed encode test`);
+                        } catch (err) {
+                            console.log(`Encoder ${info.codec} failed encode test:`, err);
+                        }
                     }
                 }
                 console.log("Final supported formats:", supportedFormats);

--- a/demo/segment-picker-demo.html
+++ b/demo/segment-picker-demo.html
@@ -198,13 +198,22 @@
                     const chs = buffer.numberOfChannels;
                     const segments = [];
                     let length = 0;
-                    for (let i = 0; i < cuts.length; i += 2) {
-                        const s = Math.max(0, Math.floor(cuts[i] * sr));
-                        const e = Math.min(Math.floor(cuts[i+1] * sr), buffer.length);
-                        if (e > s) {
-                            segments.push([s, e]);
-                            length += e - s;
+                    if (cuts.length === 0) {
+                        segments.push([0, buffer.length]);
+                        length = buffer.length;
+                    } else {
+                        for (let i = 0; i < cuts.length; i += 2) {
+                            const s = Math.max(0, Math.floor(cuts[i] * sr));
+                            const e = Math.min(Math.floor(cuts[i+1] * sr), buffer.length);
+                            if (e > s) {
+                                segments.push([s, e]);
+                                length += e - s;
+                            }
                         }
+                    }
+                    if (!length) {
+                        alert("No audio to export.");
+                        return;
                     }
                     const outBuf = audioCtx.createBuffer(chs, length, sr);
                     for (let ch = 0; ch < chs; ch++) {

--- a/demo/segment-picker-demo.html
+++ b/demo/segment-picker-demo.html
@@ -423,24 +423,100 @@
                     const [oc, , pb] = await libav.ff_init_muxer(
                         {filename: `out.${fmt.ext}`, open: true}, [[c, 1, sr]]);
                     await libav.avformat_write_header(oc, 0);
-                    const inter = new Float32Array(buf.length * chs);
-                    for (let ch = 0; ch < chs; ch++) {
-                        const data = buf.getChannelData(ch);
-                        for (let i = 0; i < buf.length; i++)
-                            inter[i*chs + ch] = data[i];
-                    }
-                    const frames = [];
+                    let frames = [];
                     let pts = 0;
-                    for (let i = 0; i < buf.length; i += frame_size) {
-                        const end = Math.min(i + frame_size, buf.length);
-                        frames.push({
-                            data: inter.subarray(i*chs, end*chs),
-                            channel_layout,
-                            format: libav.AV_SAMPLE_FMT_FLT,
-                            pts,
-                            sample_rate: sr
-                        });
-                        pts += end - i;
+                    if (sample_fmt === libav.AV_SAMPLE_FMT_FLT) {
+                        const inter = new Float32Array(buf.length * chs);
+                        for (let ch = 0; ch < chs; ch++) {
+                            const data = buf.getChannelData(ch);
+                            for (let i = 0; i < buf.length; i++)
+                                inter[i*chs + ch] = data[i];
+                        }
+                        for (let i = 0; i < buf.length; i += frame_size) {
+                            const end = Math.min(i + frame_size, buf.length);
+                            frames.push({
+                                data: inter.subarray(i*chs, end*chs),
+                                channel_layout,
+                                format: sample_fmt,
+                                pts,
+                                sample_rate: sr
+                            });
+                            pts += end - i;
+                        }
+                    } else if (sample_fmt === libav.AV_SAMPLE_FMT_FLTP) {
+                        const planars = [];
+                        for (let ch = 0; ch < chs; ch++) {
+                            const src = buf.getChannelData(ch);
+                            const dst = new Float32Array(buf.length);
+                            dst.set(src);
+                            planars.push(dst);
+                        }
+                        for (let i = 0; i < buf.length; i += frame_size) {
+                            const end = Math.min(i + frame_size, buf.length);
+                            const slice = [];
+                            for (let ch = 0; ch < chs; ch++)
+                                slice.push(planars[ch].subarray(i, end));
+                            frames.push({
+                                data: slice,
+                                channel_layout,
+                                format: sample_fmt,
+                                pts,
+                                sample_rate: sr
+                            });
+                            pts += end - i;
+                        }
+                    } else if (sample_fmt === libav.AV_SAMPLE_FMT_S16 ||
+                               sample_fmt === libav.AV_SAMPLE_FMT_S32) {
+                        const is16 = sample_fmt === libav.AV_SAMPLE_FMT_S16;
+                        const Conv = is16 ? Int16Array : Int32Array;
+                        const scale = is16 ? 0x7fff : 0x7fffffff;
+                        const inter = new Conv(buf.length * chs);
+                        for (let ch = 0; ch < chs; ch++) {
+                            const data = buf.getChannelData(ch);
+                            for (let i = 0; i < buf.length; i++)
+                                inter[i*chs + ch] =
+                                    Math.max(-1, Math.min(1, data[i])) * scale;
+                        }
+                        for (let i = 0; i < buf.length; i += frame_size) {
+                            const end = Math.min(i + frame_size, buf.length);
+                            frames.push({
+                                data: inter.subarray(i*chs, end*chs),
+                                channel_layout,
+                                format: sample_fmt,
+                                pts,
+                                sample_rate: sr
+                            });
+                            pts += end - i;
+                        }
+                    } else if (sample_fmt === libav.AV_SAMPLE_FMT_S16P ||
+                               sample_fmt === libav.AV_SAMPLE_FMT_S32P) {
+                        const is16 = sample_fmt === libav.AV_SAMPLE_FMT_S16P;
+                        const Conv = is16 ? Int16Array : Int32Array;
+                        const scale = is16 ? 0x7fff : 0x7fffffff;
+                        const planars = [];
+                        for (let ch = 0; ch < chs; ch++) {
+                            const src = buf.getChannelData(ch);
+                            const dst = new Conv(buf.length);
+                            for (let i = 0; i < buf.length; i++)
+                                dst[i] = Math.max(-1, Math.min(1, src[i])) * scale;
+                            planars.push(dst);
+                        }
+                        for (let i = 0; i < buf.length; i += frame_size) {
+                            const end = Math.min(i + frame_size, buf.length);
+                            const slice = [];
+                            for (let ch = 0; ch < chs; ch++)
+                                slice.push(planars[ch].subarray(i, end));
+                            frames.push({
+                                data: slice,
+                                channel_layout,
+                                format: sample_fmt,
+                                pts,
+                                sample_rate: sr
+                            });
+                            pts += end - i;
+                        }
+                    } else {
+                        throw new Error(`Unsupported sample_fmt ${sample_fmt}`);
                     }
                     console.log(`Encoding ${frames.length} frames`);
                     const packets = await libav.ff_encode_multi(c, frame, pkt, frames, true);

--- a/demo/segment-picker-demo.html
+++ b/demo/segment-picker-demo.html
@@ -117,7 +117,27 @@
                 const supportedFormats = ["wav"];
                 for (const [fmt, info] of Object.entries(formatMap)) {
                     const codec = await libav.avcodec_find_encoder_by_name(info.codec);
-                    if (codec) supportedFormats.push(fmt);
+                    if (!codec) {
+                        console.log(`Encoder ${info.codec} missing; skipping ${fmt}`);
+                        continue;
+                    }
+                    let canUse = true;
+                    try {
+                        const [, c, frame, pkt] = await libav.ff_init_encoder(info.codec, {
+                            ctx: {
+                                bit_rate: 128000,
+                                sample_rate: buffer.sampleRate,
+                                channel_layout: buffer.numberOfChannels === 1 ? 4 : 3,
+                                channels: buffer.numberOfChannels
+                            },
+                            time_base: [1, buffer.sampleRate]
+                        });
+                        await libav.ff_free_encoder(c, frame, pkt);
+                    } catch (err) {
+                        console.log(`Encoder ${info.codec} failed init:`, err);
+                        canUse = false;
+                    }
+                    if (canUse) supportedFormats.push(fmt);
                 }
                 supportedFormats.forEach(f => {
                     const opt = dce("option");
@@ -319,6 +339,7 @@
                     const codec = await libav.avcodec_find_encoder_by_name(fmt.codec);
                     if (codec) {
                         const fmts = await libav.AVCodec_sample_fmts(codec);
+                        console.log(`Raw sample_fmts for ${fmt.codec}:`, fmts);
                         if (fmts && fmts.length) {
                             const fmtNames = [];
                             for (const f of fmts) {
@@ -332,26 +353,36 @@
                                 console.log(`Input format flt unsupported; will encode using ${chosenName}`);
                             }
                         } else {
-                            console.log(`No sample format list for encoder ${fmt.codec}`);
+                            console.log(`No sample format list for encoder ${fmt.codec}; leaving sample_fmt unspecified`);
+                            sample_fmt = undefined;
                         }
                     } else {
                         console.log(`Could not find encoder ${fmt.codec}`);
+                        sample_fmt = undefined;
                     }
 
-                    console.log(`Initializing encoder ${fmt.codec} with sample format ${await libav.av_get_sample_fmt_name(sample_fmt)}`);
-                    const [, c, frame, pkt, frame_size] =
-                        await libav.ff_init_encoder(fmt.codec, {
-                            ctx: {
-                                bit_rate: 128000,
-                                sample_fmt,
-                                sample_rate: sr,
-                                channel_layout,
-                                channels: chs
-                            },
-                            time_base: [1, sr]
-                        });
+                    const sfmtName = sample_fmt === undefined ? "default" : await libav.av_get_sample_fmt_name(sample_fmt);
+                    console.log(`Initializing encoder ${fmt.codec} (sr=${sr}, chs=${chs}, layout=${channel_layout}) with sample format ${sfmtName}`);
+                    const encOpts = {
+                        ctx: {
+                            bit_rate: 128000,
+                            sample_rate: sr,
+                            channel_layout,
+                            channels: chs
+                        },
+                        time_base: [1, sr]
+                    };
+                    if (sample_fmt !== undefined)
+                        encOpts.ctx.sample_fmt = sample_fmt;
+                    let c, frame, pkt, frame_size;
+                    try {
+                        [, c, frame, pkt, frame_size] = await libav.ff_init_encoder(fmt.codec, encOpts);
+                    } catch (err) {
+                        console.error(`ff_init_encoder failed for ${fmt.codec} with sample_fmt ${sfmtName}`, err);
+                        throw err;
+                    }
                     const ctxFmt = await libav.AVCodecContext_sample_fmt(c);
-                    console.log(`Codec context using sample format ${await libav.av_get_sample_fmt_name(ctxFmt)}`);
+                    console.log(`Codec context using sample format ${await libav.av_get_sample_fmt_name(ctxFmt)} (${ctxFmt})`);
                     const [oc, , pb] = await libav.ff_init_muxer(
                         {filename: `out.${fmt.ext}`, open: true}, [[c, 1, sr]]);
                     await libav.avformat_write_header(oc, 0);

--- a/demo/segment-picker-demo.html
+++ b/demo/segment-picker-demo.html
@@ -114,24 +114,51 @@
                 main.appendChild(exportFmtLabel);
                 const formatSel = dce("select");
                 formatSel.id = "format";
+                const sr = buffer.sampleRate;
+                const chs = buffer.numberOfChannels;
+                const channel_layout = chs === 1 ? 4 : 3;
+                console.log(`Input audio: sampleRate=${sr}, channels=${chs}, layout=${channel_layout}`);
                 const supportedFormats = ["wav"];
                 for (const [fmt, info] of Object.entries(formatMap)) {
+                    console.log(`Probing encoder ${info.codec} for format ${fmt}`);
                     const codec = await libav.avcodec_find_encoder_by_name(info.codec);
                     if (!codec) {
                         console.log(`Encoder ${info.codec} missing; skipping ${fmt}`);
                         continue;
                     }
+
+                    // Determine a usable sample format for probing
+                    let fmts = await libav.AVCodec_sample_fmts(codec);
+                    let sample_fmt = libav.AV_SAMPLE_FMT_FLT;
+                    if (fmts && fmts.length) {
+                        const fmtNames = [];
+                        for (const f of fmts) {
+                            if (f === -1) break;
+                            fmtNames.push(await libav.av_get_sample_fmt_name(f));
+                        }
+                        console.log(`Encoder ${info.codec} supports sample formats: ${fmtNames.join(", ")}`);
+                        if (!fmts.includes(sample_fmt)) sample_fmt = fmts[0];
+                    } else {
+                        console.log(`No sample format list for encoder ${info.codec}; using default`);
+                        sample_fmt = undefined;
+                    }
+                    const sfmtName = sample_fmt === undefined ? "default" : await libav.av_get_sample_fmt_name(sample_fmt);
+                    console.log(`Attempting to initialize ${info.codec} with sample format ${sfmtName}`);
+
                     let canUse = true;
                     try {
-                        const [, c, frame, pkt] = await libav.ff_init_encoder(info.codec, {
+                        const encOpts = {
                             ctx: {
                                 bit_rate: 128000,
-                                sample_rate: buffer.sampleRate,
-                                channel_layout: buffer.numberOfChannels === 1 ? 4 : 3,
-                                channels: buffer.numberOfChannels
+                                sample_rate: sr,
+                                channel_layout,
+                                channels: chs
                             },
-                            time_base: [1, buffer.sampleRate]
-                        });
+                            time_base: [1, sr]
+                        };
+                        if (sample_fmt !== undefined)
+                            encOpts.ctx.sample_fmt = sample_fmt;
+                        const [, c, frame, pkt] = await libav.ff_init_encoder(info.codec, encOpts);
                         await libav.ff_free_encoder(c, frame, pkt);
                     } catch (err) {
                         console.log(`Encoder ${info.codec} failed init:`, err);
@@ -139,6 +166,7 @@
                     }
                     if (canUse) supportedFormats.push(fmt);
                 }
+                console.log("Final supported formats:", supportedFormats);
                 supportedFormats.forEach(f => {
                     const opt = dce("option");
                     opt.value = f;
@@ -333,6 +361,7 @@
                     const sr = buf.sampleRate;
                     const chs = buf.numberOfChannels;
                     const channel_layout = chs === 1 ? 4 : 3;
+                    console.log(`Encoding using ${fmt.codec}: sr=${sr}, chs=${chs}, layout=${channel_layout}, samples=${buf.length}`);
 
                     // Determine a supported sample format and log capabilities
                     let sample_fmt = libav.AV_SAMPLE_FMT_FLT;
@@ -377,6 +406,7 @@
                     let c, frame, pkt, frame_size;
                     try {
                         [, c, frame, pkt, frame_size] = await libav.ff_init_encoder(fmt.codec, encOpts);
+                        console.log(`ff_init_encoder succeeded: frame_size=${frame_size}`);
                     } catch (err) {
                         console.error(`ff_init_encoder failed for ${fmt.codec} with sample_fmt ${sfmtName}`, err);
                         throw err;
@@ -405,6 +435,7 @@
                         });
                         pts += end - i;
                     }
+                    console.log(`Encoding ${frames.length} frames`);
                     const packets = await libav.ff_encode_multi(c, frame, pkt, frames, true);
                     await libav.ff_write_multi(oc, pkt, packets);
                     await libav.av_write_trailer(oc);


### PR DESCRIPTION
## Summary
- Populate segment picker format menu based on actual encoder support
- Define format metadata early for dynamic validation

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68a7da6646e08330ba4d6520117b0339