### PR TITLE
feat(demo): retain export links and use original filename

### DIFF
--- a/demo/segment-picker-demo.html
+++ b/demo/segment-picker-demo.html
@@ -96,6 +96,8 @@
                 const audioCtx = new AudioContext();
                 const buffer = await audioCtx.decodeAudioData(arrayBuf);
 
+                const fileBase = file.name.replace(/\.[^/.]+$/, "");
+
                 main.innerHTML = "";
 
                 const fileNameLabel = dce("label");
@@ -387,12 +389,12 @@
 
                 markBtn.onclick = () => toggleCut(audio.currentTime);
 
-                async function addDownload(buf, fmtName, name) {
+                async function addDownload(buf, fmtName, baseName) {
                     const res = await encodeBuffer(buf, fmtName);
                     if (!res)
                         return;
                     const {blob, ext} = res;
-                    const filename = name || `output.${ext}`;
+                    const filename = baseName ? `${baseName}.${ext}` : `output.${ext}`;
                     const url = URL.createObjectURL(blob);
                     outAudio.src = url;
                     const a = dce("a");
@@ -449,8 +451,7 @@
                     trimmedBuf = outBuf;
                     outPos.max = trimmedBuf.duration.toFixed(3);
                     outPos.disabled = false;
-                    downloads.innerHTML = "";
-                    await addDownload(trimmedBuf, formatSel.value);
+                    await addDownload(trimmedBuf, formatSel.value, fileBase);
                     outPos.value = "0";
                     redrawOut();
                 };


### PR DESCRIPTION
## Summary
- Preserve original file name when exporting segments to a new format
- Keep download links for all generated formats instead of replacing them

## Testing
- None

------
https://chatgpt.com/codex/tasks/task_e_68a93b6a37708330be028fece9608f7a